### PR TITLE
refactor: Relocate nav controls to bottom with arrow icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -37,18 +37,19 @@
       align-items: center;
       padding: 8px 12px;
       background-color: #e9e9e9;
-      border-bottom: 1px solid #ccc; /* Add a bottom border to separate from canvas */
+      border-top: 1px solid #ccc; /* Add a top border to separate from canvas */
     }
 
     #pdfControls button {
-      padding: 6px 12px;
+      padding: 4px 10px; /* Adjust padding for icon buttons */
       margin: 0 5px;
       border: 1px solid #bbb;
       border-radius: 4px;
       background-color: #fff;
       color: #333;
       cursor: pointer;
-      font-size: 0.9em;
+      font-size: 1.4em; /* Make arrows larger */
+      line-height: 1; /* Helps vertically center glyphs in some cases */
       transition: background-color 0.2s ease, border-color 0.2s ease;
     }
     #pdfControls button:hover {
@@ -73,29 +74,26 @@
     }
 
     @media (max-width: 480px) {
-      #pdfControls {
-        flex-direction: column;
-        padding: 10px;
+      /* Removed old column layout rules for #pdfControls, #pdfControls button, and #pageIndicator */
+      #pageIndicator {
+        font-size: 0.8em;
+        margin: 0 5px; /* Reduce margin slightly if needed */
       }
       #pdfControls button {
-        width: 70%; /* Make buttons wider */
-        margin: 5px 0; /* Add vertical margin */
-        padding: 8px 12px; /* Slightly larger tap targets */
-      }
-      #pageIndicator {
-        margin: 8px 0; /* Adjust margin for column layout */
+        font-size: 1.2em; /* Slightly smaller arrows on mobile */
+        padding: 3px 8px;
       }
     }
   </style>
 </head>
 <body>
   <div id="pdfViewerContainer">
-    <div id="pdfControls">
-      <button id="prevPage">Previous</button>
-      <span id="pageIndicator">Page <span id="page_num">0</span> / <span id="page_count">0</span></span>
-      <button id="nextPage">Next</button>
-    </div>
     <canvas id="pdfCanvas"></canvas>
+    <div id="pdfControls">
+      <button id="prevPage">&larr;</button>
+      <span id="pageIndicator">Page <span id="page_num">0</span> / <span id="page_count">0</span></span>
+      <button id="nextPage">&rarr;</button>
+    </div>
   </div>
 
   <script>


### PR DESCRIPTION
This commit addresses your feedback on the navigation controls:

- The PDF navigation controls (`#pdfControls`) have been moved from the top of the viewer (above the canvas) to the bottom (below the canvas).
- The "Previous" and "Next" buttons now use arrow icons (`&larr;` and `&rarr;`) instead of text.
- CSS styles for the controls and buttons have been updated to suit the new position and arrow content. This includes adjusting font sizes, padding, and borders.
- Responsive CSS rules (`@media (max-width: 480px)`) have been revised to ensure the arrow controls remain in a single row and are appropriately sized on smaller screens, removing the previous stacking behavior.