### PR TITLE
fix: Prevent swipe detection from interfering with pinch-zoom

### DIFF
--- a/index.html
+++ b/index.html
@@ -114,6 +114,7 @@
     let touchendY = 0;
     const minHorizontalSwipeDistance = 50; // Minimum pixels for a horizontal swipe
     const maxVerticalSwipeDistance = 75;  // Maximum vertical travel for it to still be considered a horizontal swipe
+    let isSingleTouchSwipe = false;
 
     const pageNumDisplay = document.getElementById('page_num');
     const pageCountDisplay = document.getElementById('page_count');
@@ -211,21 +212,40 @@
     }
 
     canvas.addEventListener('touchstart', function(event) {
-      touchstartX = event.changedTouches[0].screenX;
-      touchstartY = event.changedTouches[0].screenY;
+      if (event.touches.length === 1) {
+        touchstartX = event.changedTouches[0].screenX;
+        touchstartY = event.changedTouches[0].screenY;
+        isSingleTouchSwipe = true; // Potential single-finger swipe starts
+      } else {
+        isSingleTouchSwipe = false; // Multi-touch, not a swipe for page navigation
+      }
     }, false);
 
     canvas.addEventListener('touchmove', function(event) {
-      // If a horizontal swipe is potentially starting (more horizontal movement than vertical)
-      if (Math.abs(event.changedTouches[0].screenX - touchstartX) > Math.abs(event.changedTouches[0].screenY - touchstartY)) {
+      if (!isSingleTouchSwipe || event.touches.length !== 1) {
+        // Not a valid single-touch swipe scenario (either started multi-touch or became multi-touch)
+        // Allow default behavior like pinch-zoom by not calling preventDefault()
+        isSingleTouchSwipe = false; // Ensure flag is false if it became multi-touch
+        return;
+      }
+
+      // If it's a valid single-touch swipe, check for horizontal movement to prevent scroll
+      const currentX = event.changedTouches[0].screenX;
+      const currentY = event.changedTouches[0].screenY;
+      if (Math.abs(currentX - touchstartX) > Math.abs(currentY - touchstartY)) {
+        // Predominantly horizontal movement
         event.preventDefault();
       }
-    }, { passive: false }); // passive: false is needed for preventDefault to work in touchmove
+    }, { passive: false });
 
     canvas.addEventListener('touchend', function(event) {
-      touchendX = event.changedTouches[0].screenX;
-      touchendY = event.changedTouches[0].screenY;
-      handleSwipe();
+      if (isSingleTouchSwipe && event.changedTouches.length === 1) {
+        touchendX = event.changedTouches[0].screenX;
+        touchendY = event.changedTouches[0].screenY;
+        handleSwipe(); // Process the potential swipe
+      }
+      // Reset the flag after every touchend, regardless of whether a swipe was handled
+      isSingleTouchSwipe = false;
     }, false);
   </script>
 </body>


### PR DESCRIPTION
This commit refines the touch event handling for swipe navigation on the PDF canvas to resolve a conflict with pinch-to-zoom and other multi-touch gestures.

Previously, the swipe detection logic, particularly the use of `event.preventDefault()` in `touchmove`, could prevent the browser from handling multi-touch gestures like pinch-zoom correctly.

The following changes have been implemented:
- Introduced an `isSingleTouchSwipe` flag to track if a gesture starts as and continues to be a single-finger touch.
- In `touchstart`, this flag is set based on `event.touches.length`.
- In `touchmove`, `event.preventDefault()` (for horizontal scroll prevention) is only called if `isSingleTouchSwipe` is true and `event.touches.length` remains 1. If multiple touches are detected, the flag is unset, and default browser behavior is allowed.
- In `touchend`, the swipe handling logic is only invoked if the gesture was consistently a single touch.

This ensures that multi-touch gestures are ignored by the custom swipe navigation, allowing the browser to handle them (e.g., for pinch-zooming on the PDF), while single-finger swipes continue to navigate PDF pages.